### PR TITLE
added options for using Redis as Cache backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y mysql-client-5.5 libxml2-dev
 RUN docker-php-ext-install soap
 
 COPY ./bin/install-magento /usr/local/bin/install-magento
+#COPY redis.conf /var/www/htdocs/app/etc/
 
 RUN chmod +x /usr/local/bin/install-magento
 

--- a/README.md
+++ b/README.md
@@ -98,3 +98,7 @@ After calling `install-magento`, Magento is installed and ready to use. Use prov
 If you use default base url (http://local.magento) or other test url, you need to [modify your host file](http://www.howtogeek.com/howto/27350/beginner-geek-how-to-edit-your-hosts-file/) to map the host name to docker container. For Boot2Docker, use `boot2docker ip` to find the IP address.
 
 **Important**: If you do not use the default `MAGENTO_URL` you must use a hostname that contains a dot within it (e.g `foo.bar`), otherwise the [Magento admin panel login won't work](http://magento.stackexchange.com/a/7773).
+
+## Redis Cache
+
+If you want to use Redis as Cache backend see comments in Dockerfile and bin/install-magento

--- a/bin/install-magento
+++ b/bin/install-magento
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 
 php -f /var/www/htdocs/install.php -- --license_agreement_accepted "yes" --locale $MAGENTO_LOCALE --timezone $MAGENTO_TIMEZONE --default_currency $MAGENTO_DEFAULT_CURRENCY --db_host $MYSQL_HOST --db_name $MYSQL_DATABASE --db_user $MYSQL_USER --db_pass $MYSQL_PASSWORD --url $MAGENTO_URL --skip_url_validation "yes" --use_rewrites "no" --use_secure "no" --secure_base_url "" --use_secure_admin "no" --admin_firstname $MAGENTO_ADMIN_FIRSTNAME --admin_lastname $MAGENTO_ADMIN_LASTNAME --admin_email $MAGENTO_ADMIN_EMAIL --admin_username $MAGENTO_ADMIN_USERNAME --admin_password $MAGENTO_ADMIN_PASSWORD
+
+# uncomment to configure magento to use redis cache
+#sed -i 's/<active>false/<active>true/' app/etc/modules/Cm_RedisSession.xml
+#sed -i -e '/<session_save><!\[CDATA\[files\]\]><\/session_save>/{r app/etc/redis.conf' -e 'd}' app/etc/local.xml

--- a/redis.conf
+++ b/redis.conf
@@ -1,0 +1,40 @@
+<session_save>db</session_save>
+ <redis_session>                                          <!-- All options seen here are the defaults -->
+     <host>127.0.0.1</host>                               <!-- Specify an absolute path if using a unix socket -->
+     <port>6379</port>
+     <password></password>                                <!-- Specify if your Redis server requires authentication -->
+     <timeout>2.5</timeout>                               <!-- This is the Redis connection timeout, not the locking timeout -->
+     <persistent></persistent>                            <!-- Specify unique string to enable persistent connections. E.g.: sess-db0; bugs with p$
+     <db>0</db>                                           <!-- Redis database number; protection from accidental loss is improved by using a uniqu$
+     <compression_threshold>2048</compression_threshold>  <!-- Set to 0 to disable compression (recommended when suhosin.session.encrypt=on); know$
+     <compression_lib>gzip</compression_lib>              <!-- gzip, lzf, lz4 (https://github.com/kjdev/php-ext-lz4) or snappy (https://github.com$
+     <log_level>1</log_level>                             <!-- 0 (emergency: system is unusable), 4 (warning; additional information, recommended)$
+     <max_concurrency>6</max_concurrency>                 <!-- maximum number of processes that can wait for a lock on one session; for large prod$
+     <break_after_frontend>5</break_after_frontend>       <!-- seconds to wait for a session lock in the frontend; not as critical as admin -->
+     <break_after_adminhtml>30</break_after_adminhtml>
+     <first_lifetime>600</first_lifetime>                 <!-- Lifetime of session for non-bots on the first write. 0 to disable -->
+     <bot_first_lifetime>60</bot_first_lifetime>          <!-- Lifetime of session for bots on the first write. 0 to disable -->
+     <bot_lifetime>7200</bot_lifetime>                    <!-- Lifetime of session for bots on subsequent writes. 0 to disable -->
+     <disable_locking>0</disable_locking>                 <!-- Disable session locking entirely. -->
+     <min_lifetime>60</min_lifetime>                      <!-- Set the minimum session lifetime -->
+     <max_lifetime>2592000</max_lifetime>                 <!-- Set the maximum session lifetime -->
+ </redis_session>
+ <cache>
+   <backend>Cm_Cache_Backend_Redis</backend>
+   <backend_options>
+     <server>127.0.0.1</server>                               <!-- or absolute path to unix socket -->
+     <port>6379</port>
+     <persistent></persistent>                                <!-- Specify unique string to enable persistent connections. E.g.: sess-db0; bugs wi$
+     <database>0</database>                                   <!-- Redis database number; protection against accidental data loss is improved by n$
+     <password></password>                                    <!-- Specify if your Redis server requires authentication -->
+     <force_standalone>0</force_standalone>                   <!-- 0 for phpredis, 1 for standalone PHP -->
+     <connect_retries>1</connect_retries>                     <!-- Reduces errors due to random connection failures; a value of 1 will not retry a$
+     <read_timeout>10</read_timeout>                          <!-- Set read timeout duration; phpredis does not currently support setting read tim$
+     <automatic_cleaning_factor>0</automatic_cleaning_factor> <!-- Disabled by default -->
+     <compress_data>1</compress_data>                         <!-- 0-9 for compression level, recommended: 0 or 1 -->
+     <compress_tags>1</compress_tags>                         <!-- 0-9 for compression level, recommended: 0 or 1 -->
+     <compress_threshold>20480</compress_threshold>           <!-- Strings below this size will not be compressed -->
+     <compression_lib>gzip</compression_lib>                  <!-- Support gzip, lzf, lz4 (https://github.com/kjdev/php-ext-lz4) or snappy (https:$
+     <use_lua>0</use_lua>                                     <!-- Set to 1 if Lua scripts should be used for some operations -->
+   </backend_options>
+ </cache>

--- a/redis.conf
+++ b/redis.conf
@@ -1,40 +1,40 @@
 <session_save>db</session_save>
- <redis_session>                                          <!-- All options seen here are the defaults -->
-     <host>127.0.0.1</host>                               <!-- Specify an absolute path if using a unix socket -->
-     <port>6379</port>
-     <password></password>                                <!-- Specify if your Redis server requires authentication -->
-     <timeout>2.5</timeout>                               <!-- This is the Redis connection timeout, not the locking timeout -->
-     <persistent></persistent>                            <!-- Specify unique string to enable persistent connections. E.g.: sess-db0; bugs with p$
-     <db>0</db>                                           <!-- Redis database number; protection from accidental loss is improved by using a uniqu$
-     <compression_threshold>2048</compression_threshold>  <!-- Set to 0 to disable compression (recommended when suhosin.session.encrypt=on); know$
-     <compression_lib>gzip</compression_lib>              <!-- gzip, lzf, lz4 (https://github.com/kjdev/php-ext-lz4) or snappy (https://github.com$
-     <log_level>1</log_level>                             <!-- 0 (emergency: system is unusable), 4 (warning; additional information, recommended)$
-     <max_concurrency>6</max_concurrency>                 <!-- maximum number of processes that can wait for a lock on one session; for large prod$
-     <break_after_frontend>5</break_after_frontend>       <!-- seconds to wait for a session lock in the frontend; not as critical as admin -->
-     <break_after_adminhtml>30</break_after_adminhtml>
-     <first_lifetime>600</first_lifetime>                 <!-- Lifetime of session for non-bots on the first write. 0 to disable -->
-     <bot_first_lifetime>60</bot_first_lifetime>          <!-- Lifetime of session for bots on the first write. 0 to disable -->
-     <bot_lifetime>7200</bot_lifetime>                    <!-- Lifetime of session for bots on subsequent writes. 0 to disable -->
-     <disable_locking>0</disable_locking>                 <!-- Disable session locking entirely. -->
-     <min_lifetime>60</min_lifetime>                      <!-- Set the minimum session lifetime -->
-     <max_lifetime>2592000</max_lifetime>                 <!-- Set the maximum session lifetime -->
- </redis_session>
- <cache>
+<redis_session>                                          <!-- All options seen here are the defaults -->
+    <host>127.0.0.1</host>                               <!-- Specify an absolute path if using a unix socket -->
+    <port>6379</port>
+    <password></password>                                <!-- Specify if your Redis server requires authentication -->
+    <timeout>2.5</timeout>                               <!-- This is the Redis connection timeout, not the locking timeout -->
+    <persistent></persistent>                            <!-- Specify unique string to enable persistent connections. E.g.: sess-db0; bugs with phpredis and php-fpm are known: https://github.com/nicolasff/phpredis/issues/70 -->
+    <db>0</db>                                           <!-- Redis database number; protection from accidental loss is improved by using a unique DB number for sessions -->
+    <compression_threshold>2048</compression_threshold>  <!-- Set to 0 to disable compression (recommended when suhosin.session.encrypt=on); known bug with strings over 64k: https://github.com/colinmollenhour/Cm_Cache_Backend_Redis/issues/18 -->
+    <compression_lib>gzip</compression_lib>              <!-- gzip, lzf, lz4 (https://github.com/kjdev/php-ext-lz4) or snappy (https://github.com/goatherd/php-snappy) -->
+    <log_level>1</log_level>                             <!-- 0 (emergency: system is unusable), 4 (warning; additional information, recommended), 5 (notice: normal but significant condition), 6 (info: informational messages), 7 (debug: the most information for development/testing) -->
+    <max_concurrency>6</max_concurrency>                 <!-- maximum number of processes that can wait for a lock on one session; for large production clusters, set this to at least 10% of the number of PHP processes -->
+    <break_after_frontend>5</break_after_frontend>       <!-- seconds to wait for a session lock in the frontend; not as critical as admin -->
+    <break_after_adminhtml>30</break_after_adminhtml>
+    <first_lifetime>600</first_lifetime>                 <!-- Lifetime of session for non-bots on the first write. 0 to disable -->
+    <bot_first_lifetime>60</bot_first_lifetime>          <!-- Lifetime of session for bots on the first write. 0 to disable -->
+    <bot_lifetime>7200</bot_lifetime>                    <!-- Lifetime of session for bots on subsequent writes. 0 to disable -->
+    <disable_locking>0</disable_locking>                 <!-- Disable session locking entirely. -->
+    <min_lifetime>60</min_lifetime>                      <!-- Set the minimum session lifetime -->
+    <max_lifetime>2592000</max_lifetime>                 <!-- Set the maximum session lifetime -->
+</redis_session>
+<cache>
    <backend>Cm_Cache_Backend_Redis</backend>
    <backend_options>
      <server>127.0.0.1</server>                               <!-- or absolute path to unix socket -->
      <port>6379</port>
-     <persistent></persistent>                                <!-- Specify unique string to enable persistent connections. E.g.: sess-db0; bugs wi$
-     <database>0</database>                                   <!-- Redis database number; protection against accidental data loss is improved by n$
+     <persistent></persistent>                                <!-- Specify unique string to enable persistent connections. E.g.: sess-db0; bugs with phpredis and php-fpm are known: https://github.com/nicolasff/phpredis/issues/70 -->
+     <database>0</database>                                   <!-- Redis database number; protection against accidental data loss is improved by not sharing databases -->
      <password></password>                                    <!-- Specify if your Redis server requires authentication -->
      <force_standalone>0</force_standalone>                   <!-- 0 for phpredis, 1 for standalone PHP -->
-     <connect_retries>1</connect_retries>                     <!-- Reduces errors due to random connection failures; a value of 1 will not retry a$
-     <read_timeout>10</read_timeout>                          <!-- Set read timeout duration; phpredis does not currently support setting read tim$
+     <connect_retries>1</connect_retries>                     <!-- Reduces errors due to random connection failures; a value of 1 will not retry after the first failure -->
+     <read_timeout>10</read_timeout>                          <!-- Set read timeout duration; phpredis does not currently support setting read timeouts -->
      <automatic_cleaning_factor>0</automatic_cleaning_factor> <!-- Disabled by default -->
      <compress_data>1</compress_data>                         <!-- 0-9 for compression level, recommended: 0 or 1 -->
      <compress_tags>1</compress_tags>                         <!-- 0-9 for compression level, recommended: 0 or 1 -->
      <compress_threshold>20480</compress_threshold>           <!-- Strings below this size will not be compressed -->
-     <compression_lib>gzip</compression_lib>                  <!-- Support gzip, lzf, lz4 (https://github.com/kjdev/php-ext-lz4) or snappy (https:$
+     <compression_lib>gzip</compression_lib>                  <!-- Support gzip, lzf, lz4 (https://github.com/kjdev/php-ext-lz4) or snappy (https://github.com/goatherd/php-snappy) -->
      <use_lua>0</use_lua>                                     <!-- Set to 1 if Lua scripts should be used for some operations -->
    </backend_options>
- </cache>
+</cache>


### PR DESCRIPTION
I wanted to use Redis as Cache backend so I added some configs for it. Disabled by default.

Its quite simple: 
uncomment the "redis" lines in Dockerfile and bin/install-magento. Optionally you can edit redis.conf file to your needs. It has default values from app/etc/local.xml.additional
