### PR TITLE
Fully automating install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+magento

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sailthru-magento-extension"]
+	path = sailthru-magento-extension
+	url = git@github.com:sailthru/sailthru-magento-extension.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,9 @@ FROM occitech/magento:php5.5-apache
 
 ENV MAGENTO_VERSION 1.9.2.4
 
-RUN cd /tmp && curl https://codeload.github.com/OpenMage/magento-mirror/tar.gz/$MAGENTO_VERSION -o $MAGENTO_VERSION.tar.gz && tar xvf $MAGENTO_VERSION.tar.gz && mv magento-mirror-$MAGENTO_VERSION/* magento-mirror-$MAGENTO_VERSION/.htaccess /var/www/htdocs
-
-RUN chown -R www-data:www-data /var/www/htdocs
-
 RUN apt-get update && apt-get install -y mysql-client-5.5 libxml2-dev
 RUN docker-php-ext-install soap
 
-COPY ./bin/install-magento /usr/local/bin/install-magento
-#COPY redis.conf /var/www/htdocs/app/etc/
-
-RUN chmod +x /usr/local/bin/install-magento
-
-COPY ./sampledata/magento-sample-data-1.9.1.0.tgz /opt/
-COPY ./bin/install-sampledata-1.9 /usr/local/bin/install-sampledata
-RUN chmod +x /usr/local/bin/install-sampledata
-
-VOLUME /var/www/htdocs
+COPY ./bin/entrypoint /usr/local/bin/entrypoint
+RUN chmod +x /usr/local/bin/entrypoint
+ENTRYPOINT entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,7 @@ RUN docker-php-ext-install soap
 
 COPY ./bin/entrypoint /usr/local/bin/entrypoint
 RUN chmod +x /usr/local/bin/entrypoint
+
+USER 1000
+
 ENTRYPOINT entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,8 @@ ENV MAGENTO_VERSION 1.9.2.4
 
 RUN apt-get update && apt-get install -y mysql-client-5.5 libxml2-dev
 RUN docker-php-ext-install soap
-
 COPY ./bin/entrypoint /usr/local/bin/entrypoint
 RUN chmod +x /usr/local/bin/entrypoint
-
-USER 1000
-
+RUN mkdir ~/sailthru
+WORKDIR /var/www/html
 ENTRYPOINT entrypoint

--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+chmod +x /usr/local/bin/install-magento
+install-magento

--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 chmod +x /usr/local/bin/install-magento
-install-magento
+su -c install-magento

--- a/bin/install-magento
+++ b/bin/install-magento
@@ -1,27 +1,40 @@
 #!/usr/bin/env bash
 chmod +x /usr/local/bin/install-sampledata
-cd /var/www/htdocs
-if [ -f ./sailthru.txt ]; then
+cd /var/www/html
+if [ -f ./app/etc/local.xml ]; then
   echo "It appears Magento is already installed. Running server...";
 else
-echo "Creating Mangeto CE Project";
-rm -rf ./*
-find ./ -type f -name '.*' -exec rm '{}' \;
-cd /tmp && curl https://codeload.github.com/OpenMage/magento-mirror/tar.gz/$MAGENTO_VERSION -o $MAGENTO_VERSION.tar.gz && tar xvf $MAGENTO_VERSION.tar.gz && mv magento-mirror-$MAGENTO_VERSION/* magento-mirror-$MAGENTO_VERSION/.htaccess /var/www/htdocs
-echo "sample data deploying";
-install-sampledata
-echo "sample data deployed";
-echo "installing Magento 1.9";
-php -f /var/www/htdocs/install.php -- \
-	--license_agreement_accepted "yes" --locale $MAGENTO_LOCALE --timezone $MAGENTO_TIMEZONE \
-	 --default_currency $MAGENTO_DEFAULT_CURRENCY --db_host $MYSQL_HOST --db_name $MYSQL_DATABASE \
-	 --db_user $MYSQL_USER --db_pass $MYSQL_PASSWORD \
-	 --url $MAGENTO_URL --skip_url_validation "yes" --use_rewrites "no" \
-	 --use_secure "no" --secure_base_url "" --use_secure_admin "no" \
-	 --admin_firstname $MAGENTO_ADMIN_FIRSTNAME --admin_lastname $MAGENTO_ADMIN_LASTNAME \
-	 --admin_email $MAGENTO_ADMIN_EMAIL --admin_username $MAGENTO_ADMIN_USERNAME --admin_password $MAGENTO_ADMIN_PASSWORD
-chown -R www-data:www-data /var/www/htdocs
-echo "Magento 1.9 installed";
-touch /var/www/htdocs/sailthru.txt
+	echo "Creating Mangeto CE Project";
+	rm -rf ./*
+	find ./ -type f -name '.*' -exec rm '{}' \;
+	cd /tmp && curl https://codeload.github.com/OpenMage/magento-mirror/tar.gz/$MAGENTO_VERSION -o $MAGENTO_VERSION.tar.gz && tar xvf $MAGENTO_VERSION.tar.gz && mv magento-mirror-$MAGENTO_VERSION/* magento-mirror-$MAGENTO_VERSION/.htaccess /var/www/html
+	echo "sample data deploying";
+	install-sampledata
+	EXITCODE=$?; if [[ $EXITCODE != 0 ]]; then exit $EXITCODE; fi
+	echo "sample data deployed";
+	echo "installing Magento 1.9";
+	php -f /var/www/html/install.php -- \
+		--license_agreement_accepted "yes" --locale $MAGENTO_LOCALE --timezone $MAGENTO_TIMEZONE \
+		 --default_currency $MAGENTO_DEFAULT_CURRENCY --db_host $MYSQL_HOST --db_name $MYSQL_DATABASE \
+		 --db_user $MYSQL_USER --db_pass $MYSQL_PASSWORD \
+		 --url $MAGENTO_URL --skip_url_validation "yes" --use_rewrites "no" \
+		 --use_secure "no" --secure_base_url "" --use_secure_admin "no" \
+		 --admin_firstname $MAGENTO_ADMIN_FIRSTNAME --admin_lastname $MAGENTO_ADMIN_LASTNAME \
+		 --admin_email $MAGENTO_ADMIN_EMAIL --admin_username $MAGENTO_ADMIN_USERNAME --admin_password $MAGENTO_ADMIN_PASSWORD
+	EXITCODE=$?; if [[ $EXITCODE != 0 ]]; then exit $EXITCODE; fi
+	echo "Magento 1.9 installed";
+	cd /var/www/html
+	if [ -d ".modman" ]; then
+		echo "Enabling symlinks in Magento";
+		n98-magerun dev:symlinks --on --global
+		echo "Installing modman";
+		bash < <(curl -s -L https://raw.github.com/colinmollenhour/modman/master/modman-installer)
+		source ~/.profile
+		echo "Setting up modman + sailthru";
+		modman init  
+		modman link /var/www/sailthru
+		echo "Finished Sailthru setup"
+	fi
 fi
+chown -R www-data:www-data /var/www/html
 apache2-foreground

--- a/bin/install-magento
+++ b/bin/install-magento
@@ -1,7 +1,27 @@
 #!/usr/bin/env bash
-
-php -f /var/www/htdocs/install.php -- --license_agreement_accepted "yes" --locale $MAGENTO_LOCALE --timezone $MAGENTO_TIMEZONE --default_currency $MAGENTO_DEFAULT_CURRENCY --db_host $MYSQL_HOST --db_name $MYSQL_DATABASE --db_user $MYSQL_USER --db_pass $MYSQL_PASSWORD --url $MAGENTO_URL --skip_url_validation "yes" --use_rewrites "no" --use_secure "no" --secure_base_url "" --use_secure_admin "no" --admin_firstname $MAGENTO_ADMIN_FIRSTNAME --admin_lastname $MAGENTO_ADMIN_LASTNAME --admin_email $MAGENTO_ADMIN_EMAIL --admin_username $MAGENTO_ADMIN_USERNAME --admin_password $MAGENTO_ADMIN_PASSWORD
-
-# uncomment to configure magento to use redis cache
-#sed -i 's/<active>false/<active>true/' app/etc/modules/Cm_RedisSession.xml
-#sed -i -e '/<session_save><!\[CDATA\[files\]\]><\/session_save>/{r app/etc/redis.conf' -e 'd}' app/etc/local.xml
+chmod +x /usr/local/bin/install-sampledata
+cd /var/www/htdocs
+if [ -f ./sailthru.txt ]; then
+  echo "It appears Magento is already installed. Running server...";
+else
+echo "Creating Mangeto CE Project";
+rm -rf ./*
+find ./ -type f -name '.*' -exec rm '{}' \;
+echo "sample data deploying";
+install-sampledata
+echo "sample data deployed";
+echo "installing Magento 1.9";
+cd /tmp && curl https://codeload.github.com/OpenMage/magento-mirror/tar.gz/$MAGENTO_VERSION -o $MAGENTO_VERSION.tar.gz && tar xvf $MAGENTO_VERSION.tar.gz && mv magento-mirror-$MAGENTO_VERSION/* magento-mirror-$MAGENTO_VERSION/.htaccess /var/www/htdocs
+chown -R www-data:www-data /var/www/htdocs
+php -f /var/www/htdocs/install.php -- \
+	--license_agreement_accepted "yes" --locale $MAGENTO_LOCALE --timezone $MAGENTO_TIMEZONE \
+	 --default_currency $MAGENTO_DEFAULT_CURRENCY --db_host $MYSQL_HOST --db_name $MYSQL_DATABASE \
+	 --db_user $MYSQL_USER --db_pass $MYSQL_PASSWORD \
+	 --url $MAGENTO_URL --skip_url_validation "yes" --use_rewrites "no" \
+	 --use_secure "no" --secure_base_url "" --use_secure_admin "no" \
+	 --admin_firstname $MAGENTO_ADMIN_FIRSTNAME --admin_lastname $MAGENTO_ADMIN_LASTNAME \
+	 --admin_email $MAGENTO_ADMIN_EMAIL --admin_username $MAGENTO_ADMIN_USERNAME --admin_password $MAGENTO_ADMIN_PASSWORD
+echo "Magento 1.9 installed";
+touch /var/www/htdocs/sailthru.txt
+fi
+apache2-foreground

--- a/bin/install-magento
+++ b/bin/install-magento
@@ -7,12 +7,11 @@ else
 echo "Creating Mangeto CE Project";
 rm -rf ./*
 find ./ -type f -name '.*' -exec rm '{}' \;
+cd /tmp && curl https://codeload.github.com/OpenMage/magento-mirror/tar.gz/$MAGENTO_VERSION -o $MAGENTO_VERSION.tar.gz && tar xvf $MAGENTO_VERSION.tar.gz && mv magento-mirror-$MAGENTO_VERSION/* magento-mirror-$MAGENTO_VERSION/.htaccess /var/www/htdocs
 echo "sample data deploying";
 install-sampledata
 echo "sample data deployed";
 echo "installing Magento 1.9";
-cd /tmp && curl https://codeload.github.com/OpenMage/magento-mirror/tar.gz/$MAGENTO_VERSION -o $MAGENTO_VERSION.tar.gz && tar xvf $MAGENTO_VERSION.tar.gz && mv magento-mirror-$MAGENTO_VERSION/* magento-mirror-$MAGENTO_VERSION/.htaccess /var/www/htdocs
-chown -R www-data:www-data /var/www/htdocs
 php -f /var/www/htdocs/install.php -- \
 	--license_agreement_accepted "yes" --locale $MAGENTO_LOCALE --timezone $MAGENTO_TIMEZONE \
 	 --default_currency $MAGENTO_DEFAULT_CURRENCY --db_host $MYSQL_HOST --db_name $MYSQL_DATABASE \
@@ -21,6 +20,7 @@ php -f /var/www/htdocs/install.php -- \
 	 --use_secure "no" --secure_base_url "" --use_secure_admin "no" \
 	 --admin_firstname $MAGENTO_ADMIN_FIRSTNAME --admin_lastname $MAGENTO_ADMIN_LASTNAME \
 	 --admin_email $MAGENTO_ADMIN_EMAIL --admin_username $MAGENTO_ADMIN_USERNAME --admin_password $MAGENTO_ADMIN_PASSWORD
+chown -R www-data:www-data /var/www/htdocs
 echo "Magento 1.9 installed";
 touch /var/www/htdocs/sailthru.txt
 fi

--- a/bin/install-magento
+++ b/bin/install-magento
@@ -24,17 +24,20 @@ else
 	EXITCODE=$?; if [[ $EXITCODE != 0 ]]; then exit $EXITCODE; fi
 	echo "Magento 1.9 installed";
 	cd /var/www/html
-	if [ -d ".modman" ]; then
-		echo "Enabling symlinks in Magento";
-		n98-magerun dev:symlinks --on --global
+	if ! [ -d "./.modman" ]; then
+		echo "modman not found."
 		echo "Installing modman";
 		bash < <(curl -s -L https://raw.github.com/colinmollenhour/modman/master/modman-installer)
-		source ~/.profile
 		echo "Setting up modman + sailthru";
+		source ~/.profile
 		modman init  
 		modman link /var/www/sailthru
+		echo "Enabling symlinks in Magento";
+		n98-magerun dev:symlinks --on --global
 		echo "Finished Sailthru setup"
 	fi
 fi
+echo "Re-owning files"
 chown -R www-data:www-data /var/www/html
+echo "Starting Apache"
 apache2-foreground

--- a/bin/install-sailthru
+++ b/bin/install-sailthru
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cd /var/www/html
+modman init  # Only if I haven't already run it before
+modman link /var/www/sailthru

--- a/bin/install-sailthru
+++ b/bin/install-sailthru
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-cd /var/www/html
-modman init  # Only if I haven't already run it before
-modman link /var/www/sailthru

--- a/bin/install-sampledata-1.9
+++ b/bin/install-sampledata-1.9
@@ -3,8 +3,6 @@
 cd /tmp
 cp /opt/magento-sample-data-1.9.1.0.tgz .
 tar xvf magento-sample-data-1.9.1.0.tgz
-mkdir /var/www/htdocs/media
-mkdir /var/www/htdocs/skin
 cp -R magento-sample-data-1.9.1.0/media/* /var/www/htdocs/media/
 cp -R magento-sample-data-1.9.1.0/skin/* /var/www/htdocs/skin/
 

--- a/bin/install-sampledata-1.9
+++ b/bin/install-sampledata-1.9
@@ -3,8 +3,9 @@
 cd /tmp
 cp /opt/magento-sample-data-1.9.1.0.tgz .
 tar xvf magento-sample-data-1.9.1.0.tgz
+mkdir /var/www/htdocs/media
+mkdir /var/www/htdocs/skin
 cp -R magento-sample-data-1.9.1.0/media/* /var/www/htdocs/media/
 cp -R magento-sample-data-1.9.1.0/skin/* /var/www/htdocs/skin/
-chown -R www-data:www-data /var/www/htdocs/media
 
 mysql -h $MYSQL_HOST -u $MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DATABASE < magento-sample-data-1.9.1.0/magento_sample_data_for_1.9.1.0.sql

--- a/bin/install-sampledata-1.9
+++ b/bin/install-sampledata-1.9
@@ -3,7 +3,7 @@
 cd /tmp
 cp /opt/magento-sample-data-1.9.1.0.tgz .
 tar xvf magento-sample-data-1.9.1.0.tgz
-cp -R magento-sample-data-1.9.1.0/media/* /var/www/htdocs/media/
-cp -R magento-sample-data-1.9.1.0/skin/* /var/www/htdocs/skin/
+cp -R magento-sample-data-1.9.1.0/media/* /var/www/html/media/
+cp -R magento-sample-data-1.9.1.0/skin/* /var/www/html/skin/
 
 mysql -h $MYSQL_HOST -u $MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DATABASE < magento-sample-data-1.9.1.0/magento_sample_data_for_1.9.1.0.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 web:
   build: .
   volumes:
-    - ./magento:/var/www/htdocs
+    - ./magento:/var/www/html
+    - ./sailthru-magento-extension:/var/www/sailthru
     - ./bin/install-magento:/usr/local/bin/install-magento
     - ./sampledata/magento-sample-data-1.9.1.0.tgz:/opt/magento-sample-data-1.9.1.0.tgz
     - ./bin/install-sampledata-1.9:/usr/local/bin/install-sampledata
@@ -18,7 +19,7 @@ web:
     - MAGENTO_LOCALE=en_GB
     - MAGENTO_TIMEZONE=Pacific/Auckland
     - MAGENTO_DEFAULT_CURRENCY=NZD
-    - MAGENTO_URL=http://local.magento
+    - MAGENTO_URL=local.magento
     - MAGENTO_ADMIN_FIRSTNAME=Admin
     - MAGENTO_ADMIN_LASTNAME=MyStore
     - MAGENTO_ADMIN_EMAIL=amdin@example.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,35 +1,39 @@
-web:
-  build: .
-  volumes:
-    - ./magento:/var/www/html
-    - ./sailthru-magento-extension:/var/www/sailthru
-    - ./bin/install-magento:/usr/local/bin/install-magento
-    - ./sampledata/magento-sample-data-1.9.1.0.tgz:/opt/magento-sample-data-1.9.1.0.tgz
-    - ./bin/install-sampledata-1.9:/usr/local/bin/install-sampledata
-  ports:
-    - "80:80"
-  links:
-    - mysql
-  environment:
-    - MYSQL_HOST=mysql
-    - MYSQL_ROOT_PASSWORD=magento
-    - MYSQL_USER=magento
-    - MYSQL_PASSWORD=magento
-    - MYSQL_DATABASE=magento
-    - MAGENTO_LOCALE=en_GB
-    - MAGENTO_TIMEZONE=Pacific/Auckland
-    - MAGENTO_DEFAULT_CURRENCY=NZD
-    - MAGENTO_URL=local.magento
-    - MAGENTO_ADMIN_FIRSTNAME=Admin
-    - MAGENTO_ADMIN_LASTNAME=MyStore
-    - MAGENTO_ADMIN_EMAIL=amdin@example.com
-    - MAGENTO_ADMIN_USERNAME=admin
-    - MAGENTO_ADMIN_PASSWORD=magentorocks1
-mysql:
-  image: mysql:5.6.23
-  environment:
-    - MYSQL_HOST=mysql
-    - MYSQL_ROOT_PASSWORD=magento
-    - MYSQL_USER=magento
-    - MYSQL_PASSWORD=magento
-    - MYSQL_DATABASE=magento
+version: '2'
+services:
+  web:
+    build: .
+    volumes:
+      - ./magento:/var/www/html
+      - ./sailthru-magento-extension:/var/www/sailthru
+      - ./bin/install-magento:/usr/local/bin/install-magento
+      - ./sampledata/magento-sample-data-1.9.1.0.tgz:/opt/magento-sample-data-1.9.1.0.tgz
+      - ./bin/install-sampledata-1.9:/usr/local/bin/install-sampledata
+    ports:
+      - "80:80"
+    links:
+      - mysql
+    environment:
+      - MYSQL_HOST=mysql
+      - MYSQL_ROOT_PASSWORD=magento
+      - MYSQL_USER=magento
+      - MYSQL_PASSWORD=magento
+      - MYSQL_DATABASE=magento
+      - MAGENTO_LOCALE=en_US
+      - MAGENTO_TIMEZONE=America/New_York
+      - MAGENTO_DEFAULT_CURRENCY=USD
+      - MAGENTO_URL=local.magento
+      - MAGENTO_ADMIN_FIRSTNAME=Admin
+      - MAGENTO_ADMIN_LASTNAME=MyStore
+      - MAGENTO_ADMIN_EMAIL=asilverman@sailthru.com
+      - MAGENTO_ADMIN_USERNAME=admin
+      - MAGENTO_ADMIN_PASSWORD=magentorocks1
+    depends_on:
+      - mysql
+  mysql:
+    image: mysql:5.6.23
+    environment:
+      - MYSQL_HOST=mysql
+      - MYSQL_ROOT_PASSWORD=magento
+      - MYSQL_USER=magento
+      - MYSQL_PASSWORD=magento
+      - MYSQL_DATABASE=magento

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,34 @@
 web:
-  image: alexcheng/magento
+  build: .
+  volumes:
+    - ./magento:/var/www/htdocs
+    - ./bin/install-magento:/usr/local/bin/install-magento
+    - ./sampledata/magento-sample-data-1.9.1.0.tgz:/opt/magento-sample-data-1.9.1.0.tgz
+    - ./bin/install-sampledata-1.9:/usr/local/bin/install-sampledata
   ports:
     - "80:80"
   links:
     - mysql
-  env_file:
-    - env
+  environment:
+    - MYSQL_HOST=mysql
+    - MYSQL_ROOT_PASSWORD=magento
+    - MYSQL_USER=magento
+    - MYSQL_PASSWORD=magento
+    - MYSQL_DATABASE=magento
+    - MAGENTO_LOCALE=en_GB
+    - MAGENTO_TIMEZONE=Pacific/Auckland
+    - MAGENTO_DEFAULT_CURRENCY=NZD
+    - MAGENTO_URL=http://local.magento
+    - MAGENTO_ADMIN_FIRSTNAME=Admin
+    - MAGENTO_ADMIN_LASTNAME=MyStore
+    - MAGENTO_ADMIN_EMAIL=amdin@example.com
+    - MAGENTO_ADMIN_USERNAME=admin
+    - MAGENTO_ADMIN_PASSWORD=magentorocks1
 mysql:
   image: mysql:5.6.23
-  env_file:
-    - env
+  environment:
+    - MYSQL_HOST=mysql
+    - MYSQL_ROOT_PASSWORD=magento
+    - MYSQL_USER=magento
+    - MYSQL_PASSWORD=magento
+    - MYSQL_DATABASE=magento

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - MAGENTO_URL=local.magento
       - MAGENTO_ADMIN_FIRSTNAME=Admin
       - MAGENTO_ADMIN_LASTNAME=MyStore
-      - MAGENTO_ADMIN_EMAIL=asilverman@sailthru.com
+      - MAGENTO_ADMIN_EMAIL=admin@example.com
       - MAGENTO_ADMIN_USERNAME=admin
       - MAGENTO_ADMIN_PASSWORD=magentorocks1
     depends_on:

--- a/startmagento
+++ b/startmagento
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+docker-compose up
+URL="$(docker exec dockermagento_web_1 bash -c 'echo $MAGENTO_URL')"
+IP="$(docker-machine ip)"
+echo "${IP} local.magento" >> /etc/hosts


### PR DESCRIPTION
`docker-compose up` will now automatically install Magento 1.9, sample data, and the Sailthru Magento plugin on first run.
